### PR TITLE
Add support for Apache storage backend

### DIFF
--- a/src/main/java/fm/last/moji/impl/FileUploadOutputStream.java
+++ b/src/main/java/fm/last/moji/impl/FileUploadOutputStream.java
@@ -92,7 +92,7 @@ class FileUploadOutputStream extends OutputStream {
           try {
             String message = httpConnection.getResponseMessage();
             int code = httpConnection.getResponseCode();
-            if (HttpURLConnection.HTTP_OK != code) {
+            if (HttpURLConnection.HTTP_OK != code && HttpURLConnection.HTTP_CREATED != code ) {
               throw new IOException(code + " " + message);
             } else {
               log.debug("Status: HTTP {} - {}", code, message);


### PR DESCRIPTION
Hi

We are using Moji with a MogileFS cluster that uses Apache as its storage backend.
And we found Apache returns 201 instead of 200 when the file was created, and it makes FileUploadOutputStream throws an IOException even the file has been uploaded to storage node correctly.

A patch for this issue is attached. I think this can help others who also using Apache as their MogileFS storage backend.
- CC
