### PR TITLE
FileLengthCommand fails with files' size > Integer.MAX_VALUE.

### DIFF
--- a/src/main/java/fm/last/moji/impl/FileLengthCommand.java
+++ b/src/main/java/fm/last/moji/impl/FileLengthCommand.java
@@ -52,7 +52,16 @@ class FileLengthCommand implements MojiCommand {
           log.debug("HTTP HEAD -> {}", path);
           httpConnection = httpFactory.newConnection(path);
           httpConnection.setRequestMethod("HEAD");
-          length = httpConnection.getContentLength();
+          // length = httpConnection.getContentLengthLong();
+          // Since getContentLengthLong() only available since Java 7, we do the conversion here.
+          String rawLength = httpConnection.getHeaderField("Content-Length");
+          
+          try{
+        	  length = Long.parseLong(rawLength);
+          } catch (NumberFormatException e) {
+        	  log.debug("Failed to parse Content-Length: {}", rawLength);
+        	  length=-1L;
+          }
           log.debug("Content-Length: {}", length);
           return;
         } catch (IOException e) {


### PR DESCRIPTION
Hello!

I tried to upload a large file to MogileFS with Moji, but got wrong file size returned (-1 instead of the file size).

It's due to current implement of FileLenghCommand uses HttpURLConnection.getContentLength() to get remote file size and getContentLength() fails when Content-Length > Integer.MAX_VALUE.

The attached patch do the conversion for Content-Length by FileLengthCommand itself. But it's possible for JDK7 to use getContentLengthLong() instead, but we keep the compatibility for older JDK in the patch.
- CC
