### PR TITLE
Fix bug in MultiHostTrackerPool.getTracker() when host is unreachable  always try same host

### DIFF
--- a/src/main/java/fm/last/moji/tracker/pool/MultiHostTrackerPool.java
+++ b/src/main/java/fm/last/moji/tracker/pool/MultiHostTrackerPool.java
@@ -93,6 +93,7 @@ public class MultiHostTrackerPool implements TrackerFactory {
     try {
       tracker = (Tracker) pool.borrowObject(managedHost);
     } catch (Exception e) {
+      managedHost.markAsFailed();
       throw new CommunicationException(String.format("Unable connect to tracker %s", managedHost), e);
     }
     return tracker;


### PR DESCRIPTION
Sorry with my previous commit I fix only when first time tracker is used. But we have bad luck with HW wrong memory corrupt one our tracker and this bug occur ;-).
