### PR TITLE
Fix wrong file size return if there's no Content-Length returned

### DIFF
--- a/src/main/java/fm/last/moji/impl/FileLengthCommand.java
+++ b/src/main/java/fm/last/moji/impl/FileLengthCommand.java
@@ -102,6 +102,12 @@ class FileLengthCommand implements MojiCommand {
     long length = 0;
     String rawLength = httpConnection.getHeaderField("Content-Length");
 
+    // Some webdav server, e.g., apache, does not return content-length header when the file size is zero
+    if(rawLength == null) {
+      log.debug("No Content-Length header found, assume the length is 0");
+      return 0;
+    }
+
     try {
       length = Long.parseLong(rawLength);
     } catch (NumberFormatException e) {

--- a/src/test/java/fm/last/moji/impl/FileLengthCommandTest.java
+++ b/src/test/java/fm/last/moji/impl/FileLengthCommandTest.java
@@ -68,6 +68,16 @@ public class FileLengthCommandTest {
   }
 
   @Test
+  public void noContentLengthHeader() throws Exception {
+    when(mockHttpConnection.getHeaderField("Content-Length")).thenReturn(null);
+    when(mockTracker.getPaths("key", "domain")).thenReturn(Collections.singletonList(url1));
+    command.executeWithTracker(mockTracker);
+
+    assertEquals(0, command.getLength());
+    verify(mockHttpConnection).disconnect();
+  }
+
+  @Test
   public void fileSizeExceedsInt() throws Exception {
     when(mockHttpConnection.getHeaderField("Content-Length")).thenReturn("2147483648");
     when(mockTracker.getPaths("key", "domain")).thenReturn(Collections.singletonList(url1));


### PR DESCRIPTION
Some webdav server, e.g., apache, does not return content-length header when the file size is zero.