### PR TITLE
Try another store path when fail to open output

### DIFF
--- a/src/main/java/fm/last/moji/impl/GetOutputStreamCommand.java
+++ b/src/main/java/fm/last/moji/impl/GetOutputStreamCommand.java
@@ -62,7 +62,7 @@ class GetOutputStreamCommand implements MojiCommand {
     for (Destination destination : destinations) {
       log.debug("Creating output stream to: {}", destination);
       try {
-        stream = new FileUploadOutputStream(trackerFactory, httpFactory, key, domain, destinations.get(0), writeLock);
+        stream = new FileUploadOutputStream(trackerFactory, httpFactory, key, domain, destination, writeLock);
         return;
       } catch (IOException e) {
         log.debug("Failed to open output -> {}", destination);


### PR DESCRIPTION
When moji failed to connect to MogileFS storage node in file upload procedure, moji should try to connect to another storage node (if available) instead of retrying the same one.

The behavior keeps availability when a storage node down suddenly.