### PR TITLE
Remove closeQuietly as close flushes the buffer and throws errors

### DIFF
--- a/src/main/java/fm/last/moji/impl/MojiImpl.java
+++ b/src/main/java/fm/last/moji/impl/MojiImpl.java
@@ -72,7 +72,7 @@ class MojiImpl implements Moji {
       outputStream.flush();
     } finally {
       IOUtils.closeQuietly(inputStream);
-      IOUtils.closeQuietly(outputStream);
+      outputStream.close();;
     }
   }
 


### PR DESCRIPTION
The exception

```
fm.last.moji.tracker.TrackerException: size_verify_error 
  Expected: 2744; actual: 0 (missing); 
  path: http://127.00.01:7500/dev102/0/000/000/0000000142.fid;
  error: Job queryworker has only 0, wants 150, making 150
```

gets swallowed by the `IOUtils`, which hides upload failures.