### PR TITLE
Improve close upload stream error handing

### DIFF
--- a/src/test/java/fm/last/moji/impl/FileUploadOutputStreamTest.java
+++ b/src/test/java/fm/last/moji/impl/FileUploadOutputStreamTest.java
@@ -112,8 +112,6 @@ public class FileUploadOutputStreamTest {
     verify(mockOutputStream).flush();
     verify(mockOutputStream).close();
     verify(mockHttpConnection).disconnect();
-    verify(mockTracker).createClose(KEY, DOMAIN, mockDestination, -1);
-    verify(mockTracker).close();
     verify(mockWriteLock).unlock();
   }
 

--- a/src/test/java/fm/last/moji/impl/FileUploadOutputStreamTest.java
+++ b/src/test/java/fm/last/moji/impl/FileUploadOutputStreamTest.java
@@ -116,6 +116,20 @@ public class FileUploadOutputStreamTest {
   }
 
   @Test
+  public void trackerClosesOnFail() throws IOException {
+    doThrow(new RuntimeException()).when(mockTracker).createClose(KEY, DOMAIN, mockDestination, 1);
+
+    try {
+      stream.write(1);
+      stream.close();
+    } catch (Exception e) {
+    }
+
+    verify(mockTracker).createClose(KEY, DOMAIN, mockDestination, 1);
+    verify(mockTracker).close();
+  }
+
+  @Test
   public void writeIntDelegates() throws IOException {
     stream.write(1);
     verify(mockOutputStream).write(1);


### PR DESCRIPTION
 - Do not send meaningless create_close to tracker when upload to store node is failed.
 - When create_close is failed, retry it again.