### PR TITLE
Remove the useless maven filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,6 @@
     </developer>
   </developers>
 
-  <build>
-    <filters>
-      <filter>${project.basedir}/src/test/resources/moji.properties</filter>
-    </filters>
-  </build>
-
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The property file filter is useless sine we initial integration test in pure Java now.