### PR TITLE
Made ManagedTrackerHost timer a daemon thread

### DIFF
--- a/src/main/java/fm/last/moji/tracker/pool/ManagedTrackerHost.java
+++ b/src/main/java/fm/last/moji/tracker/pool/ManagedTrackerHost.java
@@ -58,7 +58,7 @@ public class ManagedTrackerHost {
   }
 
   ManagedTrackerHost(InetSocketAddress address) {
-    this(address, new Timer(), Clock.INSTANCE);
+    this(address, new Timer(true), Clock.INSTANCE);
   }
 
   /**


### PR DESCRIPTION
I added the boolean flag to the Timer constructor to make it's associated thread a daemon. The reason for this change is because I am using Moji client in a console application and the timer threads are preventing the application from terminating after it has completed its processing.