### PR TITLE
Add module name in manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>fm.last.moji</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
So projects depend on moji are allowed to be published to a public artifact repository.